### PR TITLE
not all executions contains assertions!

### DIFF
--- a/prober/prober.js
+++ b/prober/prober.js
@@ -96,6 +96,7 @@ class Prober {
             labelNames: ['iteration', 'position', 'request_name', 'assertion']
           });
           for (const [key, execution] of Object.entries(summary.run.executions)) {
+            if(! execution.assertions) continue;
             for (const [key2, assertion] of Object.entries(execution.assertions)) {
               assertionFailureGauge.set(
                 {


### PR DESCRIPTION
We tried to use this exporter but it was keep crashing, I followed the exception and found the problem.
not all executions contains assertions!
The line I added solve this problem.