### PR TITLE
Add HTML reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@ Display overview page
 * `GET /probe/:probe[?debug=true]`\
 Run probe and show metrics\
 *Parameters*:\
-`probe`: (required) the probe to run. E. g. /probe/example\
+`probe`: (required) the probe to run. E. g. /probe/example
 *Arguments*:\
 `?debug=true`: (optional) If added, newmans [run summary object](https://github.com/postmanlabs/newman#newmanruncallbackerror-object--summary-object) is returned instead of metrics. Probe debug also needs to be enabled in configuration.
 
 * `GET /htmlreport/:probe`\
 Get HTML report for probe\
 *Parameters*:\
-`probe`: (required) the probe for which to retrieve the HTML report. E. g. /htmlreport/example\
+`probe`: (required) the probe for which to retrieve the HTML report. E. g. /htmlreport/example
 
 * `GET /config`\
 Show active configuration

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ Run probe and show metrics\
 *Arguments*:\
 `?debug=true`: (optional) If added, newmans [run summary object](https://github.com/postmanlabs/newman#newmanruncallbackerror-object--summary-object) is returned instead of metrics. Probe debug also needs to be enabled in configuration.
 
+* `GET /htmlreport/:probe`\
+Get HTML report for probe\
+*Parameters*:\
+`probe`: (required) the probe for which to retrieve the HTML report. E. g. /htmlreport/example\
+
 * `GET /config`\
 Show active configuration
 

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const register = new promClient.Registry();
 promClient.collectDefaultMetrics({ register });
 
 const app = express();
+const path = require('path');
 
 /**
  * Show index page
@@ -19,8 +20,18 @@ app.get('/', (req, res) => {
   let probes = '';
   
   Object.keys(probeConfig).forEach(probe => {
-    probes += `
-      <li><a href="probe/${probe}">${probe}</a></li>`;
+    if (probeConfig[probe].options.hasOwnProperty('reporter')) {
+      if (probeConfig[probe].options.reporter.hasOwnProperty('html')) {
+        probes += `
+          <li><a href="probe/${probe}">${probe}</a> (<a href="htmlreport/${probe}">HTML report</a>)</li>`;
+      } else {
+        probes += `
+          <li><a href="probe/${probe}">${probe}</a></li>`;
+      }
+    } else {
+      probes += `
+        <li><a href="probe/${probe}">${probe}</a></li>`;
+    }
   });
 
   res.send(`<html>
@@ -73,6 +84,21 @@ app.get('/config', (req, res) => {
 app.get('/-/ready', (req, res) => {
   logger.debug('return /-/ready');
   res.send('ready');
+});
+
+/**
+ * Returns HTML report if used
+ */
+ app.get('/htmlreport/:probe', (req, res) => {
+  try {
+    logger.debug(`return /htmlreport/'${req.params.probe}'`);
+    let htmlFile = probeConfig[req.params.probe].options.reporter.html.export;
+    res.sendFile(path.join(__dirname, htmlFile));
+  }
+  catch {
+    logger.info(`requested probe '${req.params.probe}' or html report not found`);
+    return res.status(404).send('HTML report not found');
+  }
 });
 
 const server = app.listen(config.serverPort, () => logger.info(`postman exporter running on port ${config.serverPort}`));

--- a/main.js
+++ b/main.js
@@ -21,7 +21,7 @@ app.get('/', (req, res) => {
   
   Object.keys(probeConfig).forEach(probe => {
     if (probeConfig[probe].options.hasOwnProperty('reporter')) {
-      if (probeConfig[probe].options.reporter.hasOwnProperty('html')) {
+      if (probeConfig[probe].options.reporter.hasOwnProperty('htmlextra')) {
         probes += `
           <li><a href="probe/${probe}">${probe}</a> (<a href="htmlreport/${probe}">HTML report</a>)</li>`;
       } else {
@@ -92,7 +92,7 @@ app.get('/-/ready', (req, res) => {
  app.get('/htmlreport/:probe', (req, res) => {
   try {
     logger.debug(`return /htmlreport/'${req.params.probe}'`);
-    let htmlFile = probeConfig[req.params.probe].options.reporter.html.export;
+    let htmlFile = probeConfig[req.params.probe].options.reporter.htmlextra.export;
     res.sendFile(path.join(__dirname, htmlFile));
   }
   catch {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "express": "^4.17.3",
         "newman": "^5.3.2",
+        "newman-reporter-htmlextra": "^1.22.11",
         "npm": "^8.5.3",
         "prom-client": "^14.0.1",
         "winston": "^3.6.0"
@@ -1799,6 +1800,47 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/newman-reporter-htmlextra": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/newman-reporter-htmlextra/-/newman-reporter-htmlextra-1.22.11.tgz",
+      "integrity": "sha512-7Kp2y8U9kUy14dVVX3AxRPsI/d1RiFt3AG0dw8EW+INSCRV9AWEp4AY0j/nE6m3cCMylUKJVKBYYenReo/qssA==",
+      "dependencies": {
+        "@budibase/handlebars-helpers": "0.11.8",
+        "chalk": "4.1.2",
+        "cli-progress": "3.10.0",
+        "commander": "6.2.1",
+        "filesize": "6.4.0",
+        "handlebars": "4.7.7",
+        "lodash": "4.17.21",
+        "moment-timezone": "0.5.35",
+        "pretty-ms": "7.0.1"
+      },
+      "bin": {
+        "newman-reporter-htmlextra": "bin/htmlextra.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "newman": "^5.1.2"
+      }
+    },
+    "node_modules/newman-reporter-htmlextra/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/newman-reporter-htmlextra/node_modules/filesize": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
+      "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/node-oauth1": {
@@ -6604,6 +6646,34 @@
         "tough-cookie": "3.0.1",
         "word-wrap": "1.2.3",
         "xmlbuilder": "15.1.1"
+      }
+    },
+    "newman-reporter-htmlextra": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/newman-reporter-htmlextra/-/newman-reporter-htmlextra-1.22.11.tgz",
+      "integrity": "sha512-7Kp2y8U9kUy14dVVX3AxRPsI/d1RiFt3AG0dw8EW+INSCRV9AWEp4AY0j/nE6m3cCMylUKJVKBYYenReo/qssA==",
+      "requires": {
+        "@budibase/handlebars-helpers": "0.11.8",
+        "chalk": "4.1.2",
+        "cli-progress": "3.10.0",
+        "commander": "6.2.1",
+        "filesize": "6.4.0",
+        "handlebars": "4.7.7",
+        "lodash": "4.17.21",
+        "moment-timezone": "0.5.35",
+        "pretty-ms": "7.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+        },
+        "filesize": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
+          "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ=="
+        }
       }
     },
     "node-oauth1": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "npm": "^8.5.3",
     "prom-client": "^14.0.1",
     "winston": "^3.6.0",
-    "newman-reporter-html": "^1.0.5"
+    "newman-reporter-htmlextra": "^1.22.11"
   },
   "devDependencies": {
     "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "newman": "^5.3.2",
     "npm": "^8.5.3",
     "prom-client": "^14.0.1",
-    "winston": "^3.6.0"
+    "winston": "^3.6.0",
+    "newman-reporter-html": "^1.0.5"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
There is an official HTML reporter for Newman that creates reports in HTML (https://github.com/postmanlabs/newman-reporter-html).

This PR adds newman-reporter-html as a dependency and serves up the generated HTML report(s) at `/htmlreport/<probe>`. Links to the HTML report are also shown on the root page (only if they are enabled in the probeConfiguration).

To enable HTML report for a collection, `options.reporter.html.export` and `options.reporters: 'html'` must be set.

Example:
```
module.exports = {
    "collection": {
        options: {
            collection: require('./collection.json'),
            environment: require('./environment.json'),
            timeoutRequest: 30000,
            reporters: 'html',
            reporter: {
              html: {
                export: './collectionHtmlReport.html'
              }
            }
        }
    }
};
```