### PR TITLE
Fix issues with docker multiarch build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-alpine 
+FROM node:21-bookworm-slim
 
 RUN mkdir /app && chown -R node:node /app
 


### PR DESCRIPTION
Use debian iinstead of alpine to fix issue with quemu multiarch build not working for armv7 with node:alpine

See also
https://github.com/nodejs/docker-node/issues/1798